### PR TITLE
fix(sampling): make sample_noise / sample_time follow autocast dtype

### DIFF
--- a/utils/sampling.py
+++ b/utils/sampling.py
@@ -4,16 +4,55 @@
 # Released by Spirit AI Team.
 # ==============================================================================
 
+from typing import Optional
+
 import torch
+
+
+def _resolve_dtype(dtype: Optional[torch.dtype]) -> torch.dtype:
+    """If caller passes None, follow the active autocast dtype (if any),
+    else fall back to float32 to preserve existing behaviour."""
+    if dtype is not None:
+        return dtype
+    if torch.is_autocast_enabled():
+        return torch.get_autocast_gpu_dtype()
+    return torch.float32
+
 
 def sample_beta(alpha: float, beta: float, bsize: int, device) -> torch.Tensor:
     m = torch.distributions.beta.Beta(torch.tensor([alpha]), torch.tensor([beta]))
     return m.sample((bsize,)).to(device).reshape((bsize,))
 
-def sample_noise(shape, device) -> torch.Tensor:
-    return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)
 
-def sample_time(bsize: int, device) -> torch.Tensor:
+def sample_noise(
+    shape, device, dtype: Optional[torch.dtype] = None
+) -> torch.Tensor:
+    """Draw standard-normal noise.
+
+    Args:
+        shape:  noise tensor shape
+        device: target device
+        dtype:  desired dtype. If ``None`` and we're inside an autocast
+            context, follows the autocast dtype to avoid mismatches
+            downstream (e.g. bf16 DiT ``action_in_proj``). Otherwise
+            defaults to ``torch.float32``, preserving the original behaviour.
+    """
+    return torch.normal(
+        mean=0.0, std=1.0, size=shape,
+        dtype=_resolve_dtype(dtype), device=device,
+    )
+
+
+def sample_time(
+    bsize: int, device, dtype: Optional[torch.dtype] = None
+) -> torch.Tensor:
+    """Draw flow-matching timesteps in (0, 1).
+
+    Args:
+        bsize:  batch size
+        device: target device
+        dtype:  desired dtype, see :func:`sample_noise`.
+    """
     time_beta = sample_beta(1.5, 1.0, bsize, device)
     time = time_beta * 0.999 + 0.001
-    return time.to(dtype=torch.float32, device=device)
+    return time.to(dtype=_resolve_dtype(dtype), device=device)


### PR DESCRIPTION
## Summary

Make `sample_noise` and `sample_time` in `utils/sampling.py` honor the
active `torch.autocast` dtype, instead of hardcoding `torch.float32`.

Adds an optional `dtype: Optional[torch.dtype]` kwarg to both
functions. When `None` (the default — preserves all existing call
sites' behaviour), the helper inspects the autocast context: if
autocast is enabled, it follows the autocast dtype; otherwise it
falls back to `fp32`. Backwards-compatible.

## The bug

When loading Spirit v1.5 in `bf16` for consumer-GPU deployment (the
21 GB fp32 weights OOM a 24 GB card), the standard pattern is:

```python
with torch.autocast("cuda", dtype=torch.bfloat16):
    out = policy.select_action(batch)
```

This raises:

```
RuntimeError: mat1 and mat2 must have the same dtype, but got
              Float and BFloat16
```

Trace: DiT's `action_in_proj` receives `bf16` inputs (from the model
under autocast), but `sample_noise` returns `fp32` per its hardcoded
`dtype=torch.float32` argument.

## The fix

```python
from typing import Optional
import torch


def _resolve_dtype(dtype: Optional[torch.dtype]) -> torch.dtype:
    """If caller passes None, follow the active autocast dtype (if any),
    else fall back to float32 to preserve existing behaviour."""
    if dtype is not None:
        return dtype
    if torch.is_autocast_enabled():
        return torch.get_autocast_gpu_dtype()
    return torch.float32


def sample_noise(shape, device, dtype: Optional[torch.dtype] = None):
    return torch.normal(
        mean=0.0, std=1.0, size=shape,
        dtype=_resolve_dtype(dtype), device=device,
    )


def sample_time(bsize: int, device, dtype: Optional[torch.dtype] = None):
    time_beta = sample_beta(1.5, 1.0, bsize, device)
    time = time_beta * 0.999 + 0.001
    return time.to(dtype=_resolve_dtype(dtype), device=device)
```

## Backwards compatibility

All current call sites pass two positional args:
- `model/modeling_spirit_vla.py:637`
- `model/modeling_spirit_vla.py:781-782`

These continue to work identically when not inside `torch.autocast`.
When inside `torch.autocast`, the new behaviour fixes a previously
broken path.

## Tests

```python
import torch
from utils.sampling import sample_noise, sample_time

# back-compat
assert sample_noise((2,60,14), 'cpu').dtype == torch.float32

# explicit
assert sample_noise((2,60,14), 'cpu', dtype=torch.bfloat16).dtype == torch.bfloat16

# under autocast on cuda — follows autocast dtype automatically
with torch.autocast('cuda', dtype=torch.bfloat16):
    n = sample_noise((2,60,14), 'cuda')
    assert n.dtype == torch.bfloat16
```

## Context

Part of an effort to reproduce Spirit v1.5 on a single RTX 3090. With
this fix plus a few other consumer-GPU workarounds (image dtype
handling, `torch_dtype` parameter at load time, etc.), the model runs
at ~6.1 Hz steady-state, ~10 GB GPU memory.

Engineering notes from the reproduction effort:
[lz-googlefycy/vla-lab](https://github.com/lz-googlefycy/vla-lab/blob/main/docs/troubleshooting.md)
