### PR TITLE
feat: ROCm support, flash-attn source build, and single-GPU finetune support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 __pycache__/
+checkpoints/
+output/
+uv.lock
+.venv-cuda/
+.venv-rocm/

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ A helper script is provided:
 ./scripts/setup_env.sh rocm
 ./scripts/setup_env.sh cuda train   # optional training extras
 ./scripts/setup_env.sh rocm train   # optional training extras
-# optional: compile/install ROCm flash-attention from source
-ROCM_FLASH_ATTN=1 ./scripts/setup_env.sh rocm train
+ROCM_FLASH_ATTN=1 ./scripts/setup_env.sh rocm train  # compile/install ROCm flash-attn from source
 ```
 
 Activate the environment you want:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ A helper script is provided:
 ./scripts/setup_env.sh rocm
 ./scripts/setup_env.sh cuda train   # optional training extras
 ./scripts/setup_env.sh rocm train   # optional training extras
+# optional: compile/install ROCm flash-attention from source
+ROCM_FLASH_ATTN=1 ./scripts/setup_env.sh rocm train
 ```
 
 Activate the environment you want:
@@ -116,7 +118,9 @@ source .venv-rocm/bin/activate
 - `einops==0.8.1` - Tensor operations (required by flash-attn)
 - `flash-attn==2.8.3` - Flash Attention 2 for efficient training
 
-> **Note**: `flash-attn` requires matching CUDA and PyTorch versions. If installation fails, refer to the [flash-attn installation guide](https://github.com/Dao-AILab/flash-attention#installation-and-features). ROCm installs should omit `flash-attn` unless you know your environment supports it.
+> **Note**: ROCm users can optionally compile and install the ROCm flash-attention fork from source. See the setup script below for `ROCM_FLASH_ATTN=1`. CUDA installs should use the standard flash-attn path.
+>
+> Validation note: on AMD ROCm, training works both without flash-attn (eager attention fallback) and with flash-attn installed from source; when the import succeeds, training auto-enables FA2.
 
 ## Model Checkpoints
 | Model | Type | Link |

--- a/README.md
+++ b/README.md
@@ -59,57 +59,45 @@ spirit-v1.5/
 └── README.md                     # This file
 ```
 
-## Installation & Setup
+### Installation & Setup
 
 ### System Requirements
 - **Hardware**: Tested on NVIDIA A100 80GB GPU.
 - **Software**: Python 3.10+.
 
-### Installation Options
+### Backend-specific virtual environments
 
-#### Option 1: uv (recommended)
+PyTorch backend packages (`torch` / `torchvision`) are mutually exclusive between CUDA and ROCm in a single venv. To support both, use separate environments:
 
-**For inference only:**
+- `.venv-cuda` for CUDA PyTorch
+- `.venv-rocm` for ROCm PyTorch
+
+A helper script is provided:
+
 ```bash
-uv sync
-source .venv/bin/activate
+./scripts/setup_env.sh cuda
+./scripts/setup_env.sh rocm
+./scripts/setup_env.sh cuda train   # optional training extras
+./scripts/setup_env.sh rocm train   # optional training extras
 ```
 
-**For training:**
+Activate the environment you want:
+
 ```bash
-uv sync --extra train
-source .venv/bin/activate
+source .venv-cuda/bin/activate
+# or
+source .venv-rocm/bin/activate
 ```
-
-#### Option 2: pip
-
-**For inference only:**
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements-base.txt
-```
-
-**For training:**
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements-base.txt
-pip install -r requirements-train.txt
-```
-
-> **Note**: `flash-attn` requires matching CUDA and PyTorch versions. If installation fails, refer to the [flash-attn installation guide](https://github.com/Dao-AILab/flash-attention#installation-and-features).
 
 ### Dependency Files
-- `requirements-base.txt` - Core dependencies for inference (backward compatible)
+- `requirements-common.txt` - Shared dependencies for both backends
+- `requirements-base.txt` - Inference dependencies without backend-specific torch wheels
 - `requirements-train.txt` - Additional dependencies for training
-- `requirements.txt` - Complete dependencies (base + training)
+- `requirements.txt` - Complete shared dependencies
 - `pyproject.toml` - Project configuration with optional `[train]` extra
 
 ### Key Dependencies
-**Base (Inference):**
-- `torch==2.8.0` - PyTorch deep learning framework
-- `torchvision==0.23.0` - Computer vision utilities
+**Shared (Inference):**
 - `transformers==4.57.1` - Hugging Face transformers library
 - `diffusers==0.35.2` - Diffusion models library
 - `safetensors==0.5.3` - Safe tensor serialization
@@ -118,12 +106,17 @@ pip install -r requirements-train.txt
 - `requests==2.32.5` - HTTP library
 - `scipy==1.15.2` - Scientific computing
 
+**Backend-specific:**
+- `torch` / `torchvision` - Install from the CUDA or ROCm wheel index via `scripts/setup_env.sh`
+
 **Training (Additional):**
 - `opencv-python>=4.8.0` - Image processing for data augmentation
 - `wandb>=0.16.0` - Experiment tracking and logging
 - `tqdm>=4.66.0` - Progress bars
 - `einops==0.8.1` - Tensor operations (required by flash-attn)
 - `flash-attn==2.8.3` - Flash Attention 2 for efficient training
+
+> **Note**: `flash-attn` requires matching CUDA and PyTorch versions. If installation fails, refer to the [flash-attn installation guide](https://github.com/Dao-AILab/flash-attention#installation-and-features). ROCm installs should omit `flash-attn` unless you know your environment supports it.
 
 ## Model Checkpoints
 | Model | Type | Link |
@@ -161,6 +154,22 @@ export CKPT_PATH=/path/to/your_checkpoint_dir
 export USED_CHUNK_SIZE=60
 
 ./scripts/run_robochallenge.sh
+```
+
+### Local dry-run
+
+You can validate the checkpoint and run one synthetic local inference without connecting to RoboChallenge:
+
+```bash
+cd /path/to/spirit_vla_repo
+python -m robochallenge.run_robochallenge \
+  --single_task move_objects_into_box \
+  --robochallenge_job_id dummy_job \
+  --ckpt_path /path/to/your_checkpoint_dir \
+  --user_token dummy \
+  --used_chunk_size 60 \
+  --dry_run \
+  --dry_run_infer
 ```
 
 ## Finetune Guide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "torch==2.8.0",
-    "torchvision==0.23.0",
     "transformers==4.57.1",
     "diffusers==0.35.2",
     "safetensors==0.5.3",

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,5 @@
-# Spirit-v1.5 Base Dependencies (Inference Only)
+# Spirit-v1.5 Common Dependencies
+# Backend-specific torch/torchvision are installed separately by scripts/setup_env.sh
 # Compatible with Python 3.10+
 
 transformers==4.57.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@
 # For training and inference
 # Compatible with Python 3.10+
 
-# Base dependencies (inference)
-torch==2.8.0
-torchvision==0.23.0
+# Common dependencies
 transformers==4.57.1
 diffusers==0.35.2
 safetensors==0.5.3
@@ -17,3 +15,4 @@ scipy==1.15.2
 opencv-python>=4.8.0
 wandb>=0.16.0
 tqdm>=4.66.0
+einops==0.8.1

--- a/robochallenge/run_robochallenge.py
+++ b/robochallenge/run_robochallenge.py
@@ -1,7 +1,10 @@
 import argparse
+import io
 import logging
 import sys
 from pathlib import Path
+
+from PIL import Image
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +19,47 @@ from robochallenge.robot.job_worker import job_loop
 from robochallenge.runner.task_info import TASK_INFO
 
 
+def _blank_png_bytes(width=320, height=240, color=(0, 0, 0)):
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_dry_run_item(task_name):
+    robot_type = TASK_INFO[task_name]["robot_type"]
+    task = TASK_INFO[task_name]["task"]
+    item = {
+        "job_id": "dry-run",
+        "task": task,
+        "images": {},
+    }
+
+    if robot_type == "ARX5":
+        item["action"] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    elif robot_type == "UR5":
+        item["action"] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 255.0]
+    elif robot_type == "Franka":
+        item["action"] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+    elif robot_type == "aloha":
+        item["action"] = [
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0,
+        ]
+    else:
+        raise ValueError(f"Unsupported robot type: {robot_type}")
+
+    for image_key in {
+        TASK_INFO[task_name]["observation.images.cam_high"],
+        TASK_INFO[task_name]["observation.images.cam_left_wrist"],
+        TASK_INFO[task_name]["observation.images.cam_right_wrist"],
+    }:
+        if image_key:
+            item["images"][image_key] = _blank_png_bytes()
+
+    return item
+
+
 def control_robot():
     parser = argparse.ArgumentParser()
     parser.add_argument("--single_task", type=str, required=True)
@@ -23,6 +67,8 @@ def control_robot():
     parser.add_argument("--ckpt_path", type=str, required=True)
     parser.add_argument("--user_token", type=str, required=True)
     parser.add_argument("--used_chunk_size", type=int, default=60)
+    parser.add_argument("--dry_run", action="store_true", help="Load the checkpoint and exit without connecting to RoboChallenge")
+    parser.add_argument("--dry_run_infer", action="store_true", help="Run one local synthetic inference after loading the checkpoint")
     cfg = parser.parse_args()
 
     executor = RoboChallengeExecutor(cfg)
@@ -31,6 +77,15 @@ def control_robot():
         cfg.single_task,
         cfg.robochallenge_job_id,
     )
+
+    if cfg.dry_run:
+        logger.info("Dry-run mode enabled: skipping RoboChallenge network loop.")
+        if cfg.dry_run_infer:
+            sample = _make_dry_run_item(cfg.single_task)
+            result = executor.infer(sample)
+            logger.info("Dry-run inference succeeded; produced %d action steps.", len(result))
+        return
+
     logger.info("Waiting RC to prepare the task and send observation...")
 
     client = InterfaceClient(cfg.user_token)

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND="${1:-}"
+if [[ -z "$BACKEND" ]]; then
+  echo "Usage: $0 <cuda|rocm>" >&2
+  exit 1
+fi
+
+case "$BACKEND" in
+  cuda)
+    TORCH_INDEX_URL="https://download.pytorch.org/whl/cu128"
+    VENV_DIR=".venv-cuda"
+    ;;
+  rocm)
+    TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm7.2"
+    VENV_DIR=".venv-rocm"
+    ;;
+  *)
+    echo "Unsupported backend: $BACKEND (expected cuda or rocm)" >&2
+    exit 1
+    ;;
+esac
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  uv venv "$VENV_DIR"
+fi
+
+uv pip install --python "$VENV_DIR/bin/python" -r requirements-common.txt
+uv pip install --python "$VENV_DIR/bin/python" torch torchvision --index-url "$TORCH_INDEX_URL"
+
+if [[ "${2:-}" == "train" ]]; then
+  if [[ "$BACKEND" == "cuda" ]]; then
+    uv pip install --python "$VENV_DIR/bin/python" -r requirements-train.txt
+  else
+    uv pip install --python "$VENV_DIR/bin/python" \
+      "opencv-python>=4.8.0" \
+      "wandb>=0.16.0" \
+      "tqdm>=4.66.0" \
+      "einops==0.8.1"
+    echo "Skipping flash-attn on ROCm backend."
+  fi
+fi
+
+echo "Done. Activate with: source $VENV_DIR/bin/activate"

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -41,7 +41,14 @@ if [[ "${2:-}" == "train" ]]; then
       "wandb>=0.16.0" \
       "tqdm>=4.66.0" \
       "einops==0.8.1"
-    echo "Skipping flash-attn on ROCm backend."
+
+    if [[ "${ROCM_FLASH_ATTN:-0}" == "1" ]]; then
+      uv pip install --python "$VENV_DIR/bin/python" pip setuptools wheel psutil
+      SETUPTOOLS_USE_DISTUTILS=local "$VENV_DIR/bin/pip" install -v --no-build-isolation \
+        "git+https://github.com/ROCm/flash-attention.git"
+    else
+      echo "Skipping flash-attn on ROCm backend. Set ROCM_FLASH_ATTN=1 to compile/install it from source."
+    fi
   fi
 fi
 

--- a/train.py
+++ b/train.py
@@ -129,16 +129,19 @@ def main():
     )
 
     sampler = DistributedSampler(dataset, shuffle=True) if world_size > 1 else None
-    dataloader = DataLoader(
-        dataset,
+    dataloader_kwargs = dict(
+        dataset=dataset,
         batch_size=args.batch_size,
         sampler=sampler,
         shuffle=(sampler is None),
         num_workers=args.num_workers,
-        prefetch_factor=args.prefetch_factor,
         collate_fn=dataset.collate_fn,
         pin_memory=True,
     )
+    if args.num_workers > 0:
+        dataloader_kwargs["prefetch_factor"] = args.prefetch_factor
+
+    dataloader = DataLoader(**dataloader_kwargs)
 
     logger.print("Creating model...")
     model = SpiritVLAPolicy.from_pretrained(ckpt_path= args.pretrained_path, strict=False, train=True).to(device)


### PR DESCRIPTION
    Title:
    ROCm support, flash-attn source build, and single-GPU finetune support
    
    Description:
    This PR adds and verifies ROCm support for Spirit-v1.5, including:
    
    - Separate CUDA/ROCm virtual env setup via scripts/setup_env.sh
    - ROCm PyTorch/torchvision installation from the official ROCm wheel index
    - Optional ROCm flash-attn source build via ROCM_FLASH_ATTN=1
    - ROCm training fallback without flash-attn, with auto-FA2 enablement when available
    - Single-GPU finetune compatibility in train.py
    - README updates for ROCm setup and finetune usage
    
    Validation:
    - ROCm env setup verified on AMD MI300X
    - ROCm flash-attn compiled and imported successfully
    - Single-GPU finetune smoke test completed successfully
    - 20k-step single-GPU finetune run completed and saved checkpoints